### PR TITLE
HorizontalPodAutoscaler for tyk-gateway

### DIFF
--- a/components/tyk-gateway/templates/deployment-gw-repset.yaml
+++ b/components/tyk-gateway/templates/deployment-gw-repset.yaml
@@ -8,7 +8,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
-{{- if eq .Values.gateway.kind "Deployment" }}
+{{- if and (eq .Values.gateway.kind "Deployment") (not .Values.gateway.autoscaling.enabled) }}
   replicas: {{ .Values.gateway.replicaCount }}
 {{- end }}
   minReadySeconds: 5

--- a/components/tyk-gateway/templates/hpa.yaml
+++ b/components/tyk-gateway/templates/hpa.yaml
@@ -1,0 +1,25 @@
+{{- if and (ne .Values.gateway.kind "DaemonSet") .Values.gateway.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: gateway-{{ include "tyk-gateway.fullname" . }}
+  labels:
+    app: gateway-{{ include "tyk-gateway.fullname" . }}
+    chart: {{ include "tyk-gateway.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: {{ .Values.gateway.kind }}
+    name: gateway-{{ include "tyk-gateway.fullname" . }}
+  minReplicas: {{ default 1 .Values.gateway.autoscaling.minReplicas }}
+  maxReplicas: {{ default 3 .Values.gateway.autoscaling.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ default 60 .Values.gateway.autoscaling.averageCpuUtilization }}
+{{- end }}

--- a/components/tyk-gateway/values.yaml
+++ b/components/tyk-gateway/values.yaml
@@ -132,6 +132,13 @@ gateway:
   # replicaCount specifies number of replicas to be created if kind is Deployment.
   replicaCount: 1
 
+  # autoscaling configuration if kind IS NOT DaemonSet
+  autoscaling: {}
+  #  enabled: false
+  #  minReplicas: 1
+  #  maxReplicas: 3
+  #  averageCpuUtilization: 60
+
   image:
     # image repository for Tyk Gateway
     repository: docker.tyk.io/tyk-gateway/tyk-gateway


### PR DESCRIPTION
This PR adds support for Horizontal Pod Autoscaler object to `tyk-gateway` chart if desired k8s object kind IS NOT DaemonSet.

It's has some default values provided that can also be changed with helm sets or values file. 